### PR TITLE
[WIP] Update CI workflow to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.2', '8.3']
-        kubernetes: ['1.29.8', '1.30.4', '1.31.0']
-        laravel: ['10.*', '11.*']
+        php: ['8.3', '8.4']
+        kubernetes: ['1.31.10', '1.32.6', '1.33.2']
+        laravel: ['11.*', '12.*']
         prefer: [prefer-lowest, prefer-stable]
         include:
-          - laravel: "10.*"
-            testbench: "8.*"
           - laravel: "11.*"
             testbench: "9.*"
-        exclude:
-          - laravel: "10.*"
-            php: "8.3"
+          - laravel: "12.*"
+            testbench: "10.*"
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - K8s v${{ matrix.kubernetes }} --${{ matrix.prefer }}
 
@@ -71,7 +68,7 @@ jobs:
       - uses: medyagh/setup-minikube@latest
         name: Setup Minikube
         with:
-          minikube-version: 1.33.1
+          minikube-version: 1.36.0
           driver: docker
           container-runtime: containerd
           kubernetes-version: v${{ matrix.kubernetes }}

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ PHP K8s
 [![Total Downloads](https://poser.pugx.org/renoki-co/php-k8s/downloads)](https://packagist.org/packages/renoki-co/php-k8s)
 [![Monthly Downloads](https://poser.pugx.org/renoki-co/php-k8s/d/monthly)](https://packagist.org/packages/renoki-co/php-k8s)
 
-![v1.29.8 K8s Version](https://img.shields.io/badge/K8s%20v1.29.8-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.30.4 K8s Version](https://img.shields.io/badge/K8s%20v1.30.4-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.31.0 K8s Version](https://img.shields.io/badge/K8s%20v1.31.0-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.31.10 K8s Version](https://img.shields.io/badge/K8s%20v1.31.10-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.32.6 K8s Version](https://img.shields.io/badge/K8s%20v1.32.6-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.33.2 K8s Version](https://img.shields.io/badge/K8s%20v1.33.2-Ready-%23326ce5?colorA=306CE8&colorB=green)
 
 [![Client Capabilities](https://img.shields.io/badge/Kubernetes%20Client-Silver-blue.svg?colorB=C0C0C0&colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-capabilities)
 [![Client Support Level](https://img.shields.io/badge/Kubernetes%20Client-stable-green.svg?colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-support-level)


### PR DESCRIPTION
## Summary
- Update PHP versions to 8.3, 8.4 (latest stable)
- Update Kubernetes versions to 1.31.10, 1.32.6, 1.33.2 (current supported)
- Upgrade Laravel to 11.*, 12.* with corresponding testbench versions
- Update minikube to 1.36.0 (latest stable)
- Upgrade codecov action to v5
- Update README badges to reflect new Kubernetes versions

## Test plan
- [ ] Verify CI workflow runs successfully with new versions
- [ ] Check for any compatibility issues with PHP 8.4
- [ ] Ensure Laravel 12 support works correctly
- [ ] Validate Kubernetes version compatibility
- [ ] Test minikube 1.36.0 functionality

🤖 Generated with [Claude Code](https://claude.ai/code)