### PR TITLE
Update CI workflow: increase timeout and update versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     strategy:
       fail-fast: false
       matrix:
         php: ['8.3', '8.4']
-        kubernetes: ['1.31.10', '1.32.6', '1.33.1']
+        kubernetes: ['1.32.9', '1.33.5', '1.34.1']
         laravel: ['11.*', '12.*']
         prefer: [prefer-lowest, prefer-stable]
         include:
@@ -68,7 +68,7 @@ jobs:
       - uses: medyagh/setup-minikube@latest
         name: Setup Minikube
         with:
-          minikube-version: 1.36.0
+          minikube-version: 1.37.0
           driver: docker
           container-runtime: containerd
           kubernetes-version: v${{ matrix.kubernetes }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,8 +173,9 @@ These hit a live Kubernetes cluster and mirror CI.
   7. Create PR against `cuppett/php-k8s` main branch: `gh pr create --repo cuppett/php-k8s --base main --title "..." --body "..."`
 
 **Releasing & CI (Reference)**
-- CI matrix runs PHP 8.3/8.4 across Kubernetes v1.31.10, v1.32.6, v1.33.1 and Laravel 11/12 with both `prefer-lowest` and `prefer-stable`.
-- Minikube is provisioned in CI with VolumeSnapshots, CSI hostpath, metrics‑server, VPA, Sealed Secrets CRD, and Gateway API CRDs before running tests.
+- CI matrix runs PHP 8.3/8.4 across Kubernetes v1.32.9, v1.33.5, v1.34.1 and Laravel 11/12 with both `prefer-lowest` and `prefer-stable`.
+- Minikube v1.37.0 is provisioned in CI with VolumeSnapshots, CSI hostpath, metrics‑server, VPA, Sealed Secrets CRD, and Gateway API CRDs before running tests.
+- Timeout: 25 minutes per job.
 
 **Useful References**
 - **Documentation:** https://renoki-co.github.io/php-k8s/

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ PHP K8s
 [![Total Downloads](https://poser.pugx.org/renoki-co/php-k8s/downloads)](https://packagist.org/packages/renoki-co/php-k8s)
 [![Monthly Downloads](https://poser.pugx.org/renoki-co/php-k8s/d/monthly)](https://packagist.org/packages/renoki-co/php-k8s)
 
-![v1.31.10 K8s Version](https://img.shields.io/badge/K8s%20v1.31.10-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.32.6 K8s Version](https://img.shields.io/badge/K8s%20v1.32.6-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.33.1 K8s Version](https://img.shields.io/badge/K8s%20v1.33.1-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.32.9 K8s Version](https://img.shields.io/badge/K8s%20v1.32.9-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.33.5 K8s Version](https://img.shields.io/badge/K8s%20v1.33.5-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.34.1 K8s Version](https://img.shields.io/badge/K8s%20v1.34.1-Ready-%23326ce5?colorA=306CE8&colorB=green)
 
 [![Client Capabilities](https://img.shields.io/badge/Kubernetes%20Client-Silver-blue.svg?colorB=C0C0C0&colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-capabilities)
 [![Client Support Level](https://img.shields.io/badge/Kubernetes%20Client-stable-green.svg?colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-support-level)


### PR DESCRIPTION
## Summary

This PR addresses CI timeout issues and updates all Kubernetes and tool versions to their latest stable releases.

## Changes

### CI Workflow (`.github/workflows/ci.yml`)
- **Timeout:** Increased from 15 to 25 minutes to prevent test timeouts
- **Kubernetes versions:** Updated to latest patches and added K8s 1.34 support
  - Dropped: 1.31.10 (out of support window)
  - Updated: 1.32.6 → 1.32.9
  - Updated: 1.33.1 → 1.33.5
  - Added: 1.34.1 (latest stable release)
- **Minikube:** Updated from 1.36.0 to 1.37.0 (adds Kubernetes 1.34 support)

### Documentation
- **README.md:** Updated Kubernetes version badges to reflect CI test matrix
- **AGENTS.md:** Updated CI reference section with new versions and timeout

## Testing

CI will run against the full matrix:
- PHP: 8.3, 8.4
- Kubernetes: 1.32.9, 1.33.5, 1.34.1
- Laravel: 11.*, 12.*
- Composer: prefer-lowest, prefer-stable

## Rationale

- The 15-minute timeout was causing test failures as the integration test suite grew
- Kubernetes 1.31 is approaching end of support
- Kubernetes 1.34 is the latest stable release (released August 2025)
- Minikube 1.37.0 includes support for Kubernetes 1.34 and GPU acceleration features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>