### PR TITLE
ci: bump K8s matrix to 1.35.5/1.36.1, widen testbench constraint

### DIFF
--- a/.claude/agents/integration-test-runner.md
+++ b/.claude/agents/integration-test-runner.md
@@ -34,7 +34,7 @@ You are an elite Integration Test Engineer specializing in Kubernetes client lib
    minikube stop
    minikube delete
    ```
-4. Start fresh minikube cluster matching CI configuration (currently v1.37.0 with Kubernetes versions v1.33.10, v1.34.6, or v1.35.3)
+4. Start fresh minikube cluster matching CI configuration (currently v1.38.1 with Kubernetes versions v1.35.5 or v1.36.1)
 5. Install required addons:
    - volumesnapshots
    - csi-hostpath-driver
@@ -83,8 +83,8 @@ Provide detailed, actionable reports:
 ✅ All Integration Tests Passed
 
 Environment:
-- Minikube: v1.37.0
-- Kubernetes: v1.34.6
+- Minikube: v1.38.1
+- Kubernetes: v1.36.1
 - PHP: 8.3
 - Test Duration: 12m 34s
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.3', '8.4', '8.5']
-        kubernetes: ['1.33.10', '1.34.6', '1.35.3']
+        kubernetes: ['1.35.5', '1.36.1']
         laravel: ['12.*', '13.*']
         prefer: [prefer-lowest, prefer-stable]
         include:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Pint auto-fixes:
 
 ## Running Full Integration Tests Locally
 These hit a live Kubernetes cluster and mirror CI.
-- **Start cluster:** Minikube is the reference. Example: `minikube start --kubernetes-version=v1.34.6`.
+- **Start cluster:** Minikube is the reference. Example: `minikube start --kubernetes-version=v1.36.1`.
 - **Enable addons:** `minikube addons enable volumesnapshots && minikube addons enable csi-hostpath-driver && minikube addons enable metrics-server`.
 - **Install VPA:** Clone `kubernetes/autoscaler` and run `./vertical-pod-autoscaler/hack/vpa-up.sh`. Alternatively:
   ```bash
@@ -233,8 +233,8 @@ These hit a live Kubernetes cluster and mirror CI.
   7. Create PR against `cuppett/php-k8s` main branch: `gh pr create --repo cuppett/php-k8s --base main --title "..." --body "..."`
 
 ## Releasing & CI (Reference)
-- CI matrix runs PHP 8.3-8.5 across Kubernetes v1.33.10, v1.34.6, v1.35.3 and Laravel 12/13 with both `prefer-lowest` and `prefer-stable`.
-- Minikube v1.37.0 is provisioned in CI with VolumeSnapshots, CSI hostpath, metrics‑server, VPA, Sealed Secrets CRD, and Gateway API CRDs before running tests.
+- CI matrix runs PHP 8.3-8.5 across Kubernetes v1.35.5, v1.36.1 and Laravel 12/13 with both `prefer-lowest` and `prefer-stable`.
+- Minikube v1.38.1 is provisioned in CI with VolumeSnapshots, CSI hostpath, metrics‑server, VPA, Sealed Secrets CRD, and Gateway API CRDs before running tests.
 - Timeout: 25 minutes per job.
 
 ## Useful References

--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@ PHP K8s
 
 > **Note:** This is a maintained fork of [renoki-co/php-k8s](https://github.com/renoki-co/php-k8s) with PHP 8.3+ support and additional features. See [fork differences](https://php-k8s.cuppett.dev/project/fork-differences) for details.
 
-![v1.33.10 K8s Version](https://img.shields.io/badge/K8s%20v1.33.10-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.34.6 K8s Version](https://img.shields.io/badge/K8s%20v1.34.6-Ready-%23326ce5?colorA=306CE8&colorB=green)
-![v1.35.3 K8s Version](https://img.shields.io/badge/K8s%20v1.35.3-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.35.5 K8s Version](https://img.shields.io/badge/K8s%20v1.35.5-Ready-%23326ce5?colorA=306CE8&colorB=green)
+![v1.36.1 K8s Version](https://img.shields.io/badge/K8s%20v1.36.1-Ready-%23326ce5?colorA=306CE8&colorB=green)
 
 [![Client Capabilities](https://img.shields.io/badge/Kubernetes%20Client-Silver-blue.svg?colorB=C0C0C0&colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-capabilities)
 [![Client Support Level](https://img.shields.io/badge/Kubernetes%20Client-stable-green.svg?colorA=306CE8)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-new-client-library-procedure.md#client-support-level)
@@ -21,7 +20,7 @@ For Laravel projects, you might want to use [renoki-co/laravel-php-k8s](https://
 - **Watch API**: Real-time event streaming for resource changes
 - **JSON Patch & Merge Patch**: RFC 6902 and RFC 7396 support for precise updates
 - **Custom Resources (CRDs)**: Easy CRD integration with macros
-- **PHP 8.2+ Modern Features**: Enums, type hints, readonly properties, match expressions
+- **PHP 8.3+ Modern Features**: Enums, type hints, readonly properties, match expressions
 - **Laravel Integration**: First-class Laravel support via laravel-php-k8s
 - **Flexible Authentication**: Kubeconfig, tokens, certificates, exec plugins, AWS EKS native, OpenShift OAuth
 - **YAML Import**: Load resources directly from YAML files with templating
@@ -78,8 +77,8 @@ $cluster = KubernetesCluster::fromKubeConfigYamlFile('~/.kube/config');
 
 ## 📦 Requirements
 
-- PHP 8.2 or higher
-- Laravel 11.x or 12.x (for Laravel integration)
+- PHP 8.3 or higher
+- Laravel 12.x or 13.x (for Laravel integration)
 - Kubernetes cluster access
 
 ## 📃 Documentation

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "require-dev": {
         "laravel/pint": "dev-main",
         "mockery/mockery": "^1.6",
-        "orchestra/testbench": "^11.1.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "phpunit/phpunit": "^11.5",
         "vimeo/psalm": "^6.16.1"
     },

--- a/docs/development/contributing/minikube-setup.md
+++ b/docs/development/contributing/minikube-setup.md
@@ -9,7 +9,7 @@ Detailed Minikube configuration for PHP K8s development.
 # See https://minikube.sigs.k8s.io/docs/start/
 
 # Start cluster
-minikube start --kubernetes-version=v1.34.6
+minikube start --kubernetes-version=v1.36.1
 ```
 
 ## Enable Addons

--- a/docs/development/contributing/setup.md
+++ b/docs/development/contributing/setup.md
@@ -29,7 +29,7 @@ composer install
 
 ```bash
 # Start with specific Kubernetes version
-minikube start --kubernetes-version=v1.34.6
+minikube start --kubernetes-version=v1.36.1
 
 # Enable required addons
 minikube addons enable volumesnapshots

--- a/docs/index.md
+++ b/docs/index.md
@@ -141,9 +141,8 @@ composer require renoki-co/laravel-php-k8s
 
 This library is tested against multiple Kubernetes versions:
 
-- **v1.33.10** ✅
-- **v1.34.6** ✅
-- **v1.35.3** ✅
+- **v1.35.5** ✅
+- **v1.36.1** ✅
 
 ## Requirements
 

--- a/docs/project/fork-differences.md
+++ b/docs/project/fork-differences.md
@@ -114,7 +114,7 @@ This fork may include additional Kubernetes resource types:
 ### Testing Infrastructure
 
 **This Fork**:
-- Tests against Kubernetes 1.33.10, 1.34.6, 1.35.3
+- Tests against Kubernetes 1.35.5, 1.36.1
 - Automated testing with GitHub Actions
 - Integration tests with Minikube
 - VPA, Gateway API, and Sealed Secrets CRD testing


### PR DESCRIPTION
## Summary

- Drop Kubernetes 1.33 and 1.34 from the CI matrix; target only the two newest stable minors (**1.35.5** and **1.36.1**). Reduces the job count from 36 → 24 (3×3×2×2 → 2×3×2×2).
- Widen `orchestra/testbench` from `^11.1.0` → `^10.0|^11.0` so a plain `composer install` resolves the Laravel 12 leg without CI's `--no-update` override.
- Reconcile documentation drift: README PHP/Laravel support claims, contributor setup examples (`minikube start` version), Minikube version in agent/contributor docs (`v1.37.0` → `v1.38.1`), K8s version tables in `docs/index.md` and `docs/project/fork-differences.md`.

## Test plan

- [x] `vendor/bin/pint --test` passes (no style violations)
- [x] Full integration suite run locally against Minikube v1.38.1 + K8s v1.36.1 + PHP 8.5.6: **336 tests, 2717 assertions, 0 failures, 7 expected skips**
- [x] No stale version strings remaining (`grep` across repo confirmed)
- [ ] CI green on all 24 matrix legs (pushed — awaiting GitHub Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)